### PR TITLE
Fix ignored test

### DIFF
--- a/.github/workflows/tree-sitter-core.yml
+++ b/.github/workflows/tree-sitter-core.yml
@@ -111,7 +111,7 @@ jobs:
 #          -Zprofile -Ccodegen-units=1 -Clink-dead-code -Coverflow-checks=off
 #          -Zno-landing-pads
 #      run: |
-#        cargo test --all --all-features --no-fail-fast --verbose
+#        cargo test --all --all-features --no-fail-fast --verbose --release
 #
 #    - name: Run grcov
 #      id: coverage
@@ -205,12 +205,12 @@ jobs:
     - name: Run no-default-features tests
       if: matrix.conf != 'cargo-c'
       run: |
-        cargo test --all --no-default-features
+        cargo test --all --no-default-features --release
 
     - name: Run all-features tests
       if: matrix.conf != 'cargo-c'
       run: |
-        cargo test --all --all-features
+        cargo test --all --all-features --release
 
     - name: Install cargo-c
       if: matrix.conf == 'cargo-c'
@@ -281,11 +281,11 @@ jobs:
 
     - name: Run no-default-features tests
       run: |
-        cargo test --all --no-default-features
+        cargo test --all --no-default-features --release
 
     - name: Run all-features tests
       run: |
-        cargo test --all --all-features
+        cargo test --all --all-features --release
 
     - name: Stop sccache server
       run: |
@@ -349,11 +349,11 @@ jobs:
 
     - name: Run no-default-features tests
       run: |
-        cargo test --no-default-features
+        cargo test --no-default-features --release
 
     - name: Run all-features tests
       run: |
-        cargo test --all-features
+        cargo test --all-features --release
 
     - name: Stop sccache server
       run: |

--- a/tree-sitter-tests/Cargo.toml
+++ b/tree-sitter-tests/Cargo.toml
@@ -29,6 +29,7 @@ libc = "0.2.67"
 git2 = "0.13.0"
 walkdir = "2.3.1"
 which = "3.1.1"
+rayon = "1.3.0"
 
 [dev-dependencies.serde_json]
 version = "1.0"

--- a/tree-sitter-tests/src/tests/highlight_test.rs
+++ b/tree-sitter-tests/src/tests/highlight_test.rs
@@ -402,7 +402,6 @@ fn test_highlighting_javascript_with_jsdoc() {
 }
 
 #[test]
-#[ignore]
 fn test_highlighting_with_content_children_included() {
     let source = vec!["assert!(", "    a.b.c() < D::e::<F>()", ");"].join("\n");
 

--- a/tree-sitter-tests/src/tests/query_test.rs
+++ b/tree-sitter-tests/src/tests/query_test.rs
@@ -465,7 +465,7 @@ fn test_query_matches_with_wildcard_at_the_root() {
     });
 }
 #[test]
-fn test_query_with_immediate_siblings() {
+fn test_query_matches_with_immediate_siblings() {
     allocations::record(|| {
         let language = get_language("python");
 
@@ -546,6 +546,41 @@ fn test_query_matches_in_language_with_simple_aliases() {
                 (0, vec![("tag", "style")]),
                 (0, vec![("tag", "div")]),
             ],
+        );
+    });
+}
+
+#[test]
+fn test_query_matches_with_different_tokens_with_the_same_string_value() {
+    allocations::record(|| {
+        let language = get_language("rust");
+        let query = Query::new(
+            language,
+            r#"
+                "<" @less
+                ">" @greater
+                "#,
+        )
+        .unwrap();
+
+        // In Rust, there are two '<' tokens: one for the binary operator,
+        // and one with higher precedence for generics.
+        let source = "const A: B<C> = d < e || f > g;";
+
+        let mut parser = Parser::new();
+        parser.set_language(language).unwrap();
+        let tree = parser.parse(&source, None).unwrap();
+        let mut cursor = QueryCursor::new();
+        let matches = cursor.matches(&query, tree.root_node(), to_callback(source));
+
+        assert_eq!(
+            collect_matches(matches, &query, source),
+            &[
+                (0, vec![("less", "<")]),
+                (1, vec![("greater", ">")]),
+                (0, vec![("less", "<")]),
+                (1, vec![("greater", ">")]),
+            ]
         );
     });
 }


### PR DESCRIPTION
Test `test_highlighting_with_content_children_included` was not working, but [the original issue](https://github.com/tree-sitter/tree-sitter/issues/585) has been closed.

The fixing commit has been tracked and backported, but it is not enough: `parser.c` file must be re-generated. This features has been added after the remote repository cloning/pulling phase, but it is pretty slow in debug mode. Therefore, the `release` flag for the tests has been added to the CI.